### PR TITLE
Use SpellFileMissing's <match> instead of reading spelllang

### DIFF
--- a/plugin/spellfile_nvim/init.lua
+++ b/plugin/spellfile_nvim/init.lua
@@ -1,9 +1,8 @@
 require('spellfile_nvim').setup()
 
 vim.api.nvim_create_autocmd('SpellFileMissing', {
-  callback = function()
-    local lang = vim.api.nvim_exec2('echo &spelllang', { output = true })
-    require('spellfile_nvim').load_file(lang.output)
+  callback = function(args)
+    require('spellfile_nvim').load_file(args.match)
   end,
 })
 


### PR DESCRIPTION
Thanks for the plugin!

I am using `set spelllang=en,pl` and it seems that this plugin will only ask for `en` even though the english file is already available. With this change it will use the `args.match` received from autocmd that in my case contains just `pl`.